### PR TITLE
Issue 7 user profile and search feature

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,7 +1,7 @@
 import os
 from flask import Flask
 from flask_login import LoginManager
-from .models import db, User, Category, State, Suburb
+from .models import db, User, Category, State, Suburb, Report
 
 login_manager = LoginManager()
 
@@ -51,6 +51,49 @@ def seed_locations():
             db.session.add(Suburb(name=suburb_name, state_id=state.id))
     db.session.commit()
 
+# a few arbitrary test users so the search feature has something to find
+# password for all of them is 'Test@1234' — move this to a real fixture later
+DEFAULT_TEST_USERS = [
+    ('alice',   'alice@test.com'),
+    ('bob',     'bob@test.com'),
+    ('charlie', 'charlie@test.com'),
+]
+
+# one sample report per test user so viewing their profile actually shows content
+# (suburb_name, category_name, description)
+DEFAULT_TEST_REPORTS = [
+    ('alice',   'Sydney',   'Weather', 'Heavy rain at George St, watch out for puddles.'),
+    ('bob',     'Melbourne','Traffic', 'Tram line blocked near Flinders Station.'),
+    ('charlie', 'Perth',    'Hazards', 'Fallen branch on the Kings Park path.'),
+]
+
+def seed_test_users_and_reports():
+    # add missing test users; skip any that already exist
+    for username, email in DEFAULT_TEST_USERS:
+        if User.query.filter_by(username=username).first():
+            continue
+        u = User(username=username, email=email)
+        u.set_password('Test@1234')
+        db.session.add(u)
+    db.session.commit()
+
+    # add sample reports — only if the user has none, to stay idempotent
+    for username, suburb_name, category_name, description in DEFAULT_TEST_REPORTS:
+        user = User.query.filter_by(username=username).first()
+        if not user or user.reports:
+            continue
+        suburb = Suburb.query.filter_by(name=suburb_name).first()
+        category = Category.query.filter_by(name=category_name).first()
+        if not (suburb and category):
+            continue
+        db.session.add(Report(
+            user_id=user.id,
+            suburb_id=suburb.id,
+            category_id=category.id,
+            description=description,
+        ))
+    db.session.commit()
+
 def create_app():
     app = Flask(__name__)
 
@@ -71,6 +114,7 @@ def create_app():
         from . import routes
         db.create_all()
         seed_categories()  # make sure default categories exist
-        seed_locations()   # make sure states + cities exist
+        seed_locations()   # make sure states + suburbs exist
+        seed_test_users_and_reports()  # arbitrary users so search has something to find
 
     return app

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,7 +1,7 @@
 import os
 import uuid
 from flask import current_app as app
-from flask import render_template, redirect, url_for, flash, request, jsonify
+from flask import render_template, redirect, url_for, flash, request, jsonify, abort
 from flask_login import login_user, logout_user, login_required, current_user
 from werkzeug.utils import secure_filename
 from .models import db, User, Category, Report, State, Suburb, ReportMedia
@@ -92,6 +92,57 @@ def profile_page():
         .all()
     )
     return render_template('profile.html', recent_reports=recent_reports)
+
+# /reports/<id>/edit — GET renders the edit form, POST saves changes
+# only the original author can edit; everyone else gets 403
+@app.route('/reports/<int:report_id>/edit', methods=['GET', 'POST'])
+@login_required
+def edit_report_page(report_id):
+    report = Report.query.get_or_404(report_id)
+    if report.user_id != current_user.id:
+        abort(403)
+
+    if request.method == 'POST':
+        category_id = request.form.get('category_id', type=int)
+        suburb_id = request.form.get('suburb_id', type=int)
+        description = (request.form.get('description') or '').strip()
+        address = (request.form.get('address') or '').strip() or None
+
+        # same validation rules as create — category + suburb required, address optional
+        errors = {}
+        if not category_id or not Category.query.get(category_id):
+            errors['category_id'] = 'Invalid or missing category.'
+        if not suburb_id or not Suburb.query.get(suburb_id):
+            errors['suburb_id'] = 'Invalid or missing location.'
+        if address and len(address) > 200:
+            errors['address'] = 'Address must be 200 characters or fewer.'
+
+        if not errors:
+            report.category_id = category_id
+            report.suburb_id = suburb_id
+            report.address = address
+            report.description = description
+            db.session.commit()
+            flash('Report updated.', 'success')
+            return redirect(url_for('profile_page'))
+
+        # validation failed — fall through and re-render the form showing errors
+        for msg in errors.values():
+            flash(msg, 'error')
+
+    categories = Category.query.order_by(Category.id).all()
+    states = State.query.order_by(State.name).all()
+    suburbs_by_state = {
+        s.id: [{'id': sub.id, 'name': sub.name} for sub in s.suburbs]
+        for s in states
+    }
+    return render_template(
+        'report_edit.html',
+        report=report,
+        categories=categories,
+        states=states,
+        suburbs_by_state=suburbs_by_state,
+    )
 
 # /reports — page where a logged-in user fills out and submits a report
 @app.route('/reports')

--- a/app/routes.py
+++ b/app/routes.py
@@ -91,7 +91,47 @@ def profile_page():
         .limit(5)
         .all()
     )
-    return render_template('profile.html', recent_reports=recent_reports)
+    return render_template(
+        'profile.html',
+        user=current_user,
+        recent_reports=recent_reports,
+        is_own_profile=True,
+    )
+
+# /users/<username> — view someone else's profile (read-only, no edit buttons)
+@app.route('/users/<username>')
+@login_required
+def user_profile_page(username):
+    user = User.query.filter_by(username=username).first_or_404()
+    recent_reports = (
+        Report.query
+        .filter_by(user_id=user.id)
+        .order_by(Report.created_at.desc())
+        .limit(5)
+        .all()
+    )
+    return render_template(
+        'profile.html',
+        user=user,
+        recent_reports=recent_reports,
+        is_own_profile=(user.id == current_user.id),
+    )
+
+# /search — find users by username substring (case-insensitive)
+@app.route('/search')
+@login_required
+def search_users_page():
+    q = (request.args.get('q') or '').strip()
+    users = []
+    if q:
+        users = (
+            User.query
+            .filter(User.username.ilike(f'%{q}%'))
+            .order_by(User.username)
+            .limit(20)
+            .all()
+        )
+    return render_template('search.html', q=q, users=users)
 
 # /reports/<id>/edit — GET renders the edit form, POST saves changes
 # only the original author can edit; everyone else gets 403

--- a/app/routes.py
+++ b/app/routes.py
@@ -80,6 +80,19 @@ def logout():
     logout_user()
     return redirect(url_for('login'))
 
+# /profile — show the logged-in user's own basic info
+@app.route('/profile')
+@login_required
+def profile_page():
+    recent_reports = (
+        Report.query
+        .filter_by(user_id=current_user.id)
+        .order_by(Report.created_at.desc())
+        .limit(5)
+        .all()
+    )
+    return render_template('profile.html', recent_reports=recent_reports)
+
 # /reports — page where a logged-in user fills out and submits a report
 @app.route('/reports')
 @login_required

--- a/app/routes.py
+++ b/app/routes.py
@@ -108,6 +108,16 @@ def edit_report_page(report_id):
         description = (request.form.get('description') or '').strip()
         address = (request.form.get('address') or '').strip() or None
 
+        # media edits: user may delete some existing attachments and/or add new ones
+        delete_ids = request.form.getlist('delete_media_ids', type=int)
+        new_files = [f for f in request.files.getlist('media') if f and f.filename]
+
+        # only allow deleting attachments that actually belong to THIS report
+        media_to_delete = [m for m in report.media if m.id in delete_ids]
+
+        # total files after delete + upload must stay under the limit
+        remaining_after_delete = len(report.media) - len(media_to_delete)
+
         # same validation rules as create — category + suburb required, address optional
         errors = {}
         if not category_id or not Category.query.get(category_id):
@@ -116,13 +126,54 @@ def edit_report_page(report_id):
             errors['suburb_id'] = 'Invalid or missing location.'
         if address and len(address) > 200:
             errors['address'] = 'Address must be 200 characters or fewer.'
+        if remaining_after_delete + len(new_files) > MAX_MEDIA_FILES:
+            errors['media'] = f'Too many attachments (max {MAX_MEDIA_FILES} total).'
+        else:
+            for f in new_files:
+                if not _media_type_for(f.filename):
+                    errors['media'] = f'Unsupported file type: {f.filename}'
+                    break
 
         if not errors:
             report.category_id = category_id
             report.suburb_id = suburb_id
             report.address = address
             report.description = description
-            db.session.commit()
+
+            # delete selected attachments: remove the DB row AND the file on disk
+            for m in media_to_delete:
+                disk_path = os.path.join(app.config['UPLOAD_FOLDER'], m.filename)
+                db.session.delete(m)
+                try:
+                    os.remove(disk_path)
+                except OSError:
+                    pass  # file already gone, that's fine
+
+            # save any new uploads (same pattern as the create endpoint)
+            saved_paths = []
+            try:
+                for f in new_files:
+                    ext = f.filename.rsplit('.', 1)[-1].lower()
+                    stored_name = f'{uuid.uuid4().hex}.{ext}'
+                    save_path = os.path.join(app.config['UPLOAD_FOLDER'], stored_name)
+                    f.save(save_path)
+                    saved_paths.append(save_path)
+                    db.session.add(ReportMedia(
+                        report_id=report.id,
+                        filename=stored_name,
+                        original_name=secure_filename(f.filename) or stored_name,
+                        media_type=_media_type_for(f.filename),
+                    ))
+                db.session.commit()
+            except Exception:
+                db.session.rollback()
+                for path in saved_paths:
+                    try:
+                        os.remove(path)
+                    except OSError:
+                        pass
+                raise
+
             flash('Report updated.', 'success')
             return redirect(url_for('profile_page'))
 

--- a/app/static/css/profile.css
+++ b/app/static/css/profile.css
@@ -1,0 +1,31 @@
+/* profile.html — carousel styling */
+
+/* make the carousel arrows very obvious — solid dark circles, scale up on hover */
+.carousel-control-prev,
+.carousel-control-next {
+    width: 60px;
+    opacity: 1;
+}
+
+.carousel-control-prev-icon,
+.carousel-control-next-icon {
+    background-color: rgba(0, 0, 0, 0.6);
+    border-radius: 50%;
+    width: 44px;
+    height: 44px;
+    background-size: 60%;
+    background-position: center;
+    transition: transform 0.15s ease, background-color 0.15s ease;
+}
+
+.carousel-control-prev:hover .carousel-control-prev-icon,
+.carousel-control-next:hover .carousel-control-next-icon {
+    background-color: rgba(0, 0, 0, 0.9);
+    transform: scale(1.2);
+}
+
+/* indicator dots stay visible on any background */
+.carousel-indicators [data-bs-target] {
+    background-color: rgba(255, 255, 255, 0.9);
+    border: 1px solid rgba(0, 0, 0, 0.4);
+}

--- a/app/static/css/report_edit.css
+++ b/app/static/css/report_edit.css
@@ -1,0 +1,34 @@
+/* report_edit.html — existing-attachment thumbnail + remove (X) button */
+
+.attachment-thumb {
+    position: relative;           /* so the X button can be absolute-positioned inside */
+}
+
+.attachment-thumb .remove-btn {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    border: none;
+    background-color: rgba(0, 0, 0, 0.7);
+    color: #fff;
+    font-size: 16px;
+    line-height: 1;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background-color 0.15s ease, transform 0.15s ease;
+}
+
+.attachment-thumb .remove-btn:hover {
+    background-color: rgba(220, 53, 69, 0.95);  /* bootstrap danger red */
+    transform: scale(1.1);
+}
+
+/* the checkbox is controlled by the X button — hide it visually but keep it in the form */
+.attachment-thumb input[type="checkbox"] {
+    display: none;
+}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -11,9 +11,19 @@
     <nav class="navbar navbar-dark bg-dark">
         <div class="container-fluid">
             <a class="navbar-brand" href="{{ url_for('index') }}">Global Explorer</a>
+
+            {% if current_user.is_authenticated %}
+                {# quick search bar in the navbar — jumps to the full /search page on submit #}
+                <form class="d-flex mx-3 flex-grow-1" method="get" action="{{ url_for('search_users_page') }}" style="max-width: 400px;">
+                    <input class="form-control form-control-sm" type="search" name="q"
+                           placeholder="Search users..." value="{{ request.args.get('q', '') }}">
+                    <button class="btn btn-sm btn-outline-light ms-2" type="submit">Go</button>
+                </form>
+            {% endif %}
+
             <div>
                 {% if current_user.is_authenticated %}
-                    <span class="text-light me-3">{{ current_user.username }}</span>
+                    <a href="{{ url_for('profile_page') }}" class="text-light me-3 text-decoration-none">{{ current_user.username }}</a>
                     <a href="{{ url_for('logout') }}" class="btn btn-outline-light btn-sm">Log Out</a>
                 {% else %}
                     <a href="{{ url_for('login') }}" class="btn btn-outline-light btn-sm me-2">Log In</a>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Global Explorer</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    {% block styles %}{% endblock %}
 </head>
 <body>
     <nav class="navbar navbar-dark bg-dark">

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -1,35 +1,10 @@
 {% extends "base.html" %}
 
-{% block content %}
-<style>
-    /* make the carousel arrows very obvious — solid dark circles, scale up on hover */
-    .carousel-control-prev,
-    .carousel-control-next {
-        width: 60px;
-        opacity: 1;
-    }
-    .carousel-control-prev-icon,
-    .carousel-control-next-icon {
-        background-color: rgba(0, 0, 0, 0.6);
-        border-radius: 50%;
-        width: 44px;
-        height: 44px;
-        background-size: 60%;
-        background-position: center;
-        transition: transform 0.15s ease, background-color 0.15s ease;
-    }
-    .carousel-control-prev:hover .carousel-control-prev-icon,
-    .carousel-control-next:hover .carousel-control-next-icon {
-        background-color: rgba(0, 0, 0, 0.9);
-        transform: scale(1.2);
-    }
-    /* indicator dots stay visible on any background */
-    .carousel-indicators [data-bs-target] {
-        background-color: rgba(255, 255, 255, 0.9);
-        border: 1px solid rgba(0, 0, 0, 0.4);
-    }
-</style>
+{% block styles %}
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/profile.css') }}">
+{% endblock %}
 
+{% block content %}
 <h1>My Profile</h1>
 
 <div class="card mb-4">
@@ -51,12 +26,21 @@
                 <span class="text-muted">— {{ r.created_at.strftime('%d %b %Y, %H:%M') }}</span>
                 {% if r.description %}<div class="mt-1">{{ r.description }}</div>{% endif %}
 
+                {# ---------- image/video carousel for this report ---------- #}
+                {# Only shown if the report has any attachments. Uses Bootstrap 5's carousel component. #}
                 {% if r.media %}
+                    {# unique id per report so each carousel's prev/next buttons target the right one #}
+                    {# data-bs-ride="false" means it WON'T auto-play; user clicks arrows/indicators to move #}
                     <div id="carousel-{{ r.id }}" class="carousel slide mt-2" data-bs-ride="false">
-                        {# dots at the top showing which slide you're on, 1 per media item #}
+
+                        {# ---- indicators (little bars) at the buttom showing which slide you're on ---- #}
+                        {# Bootstrap 5 renders these as thin horizontal bars by default (not dots) #}
+                        {# only shown when there's more than 1 attachment #}
                         {% if r.media | length > 1 %}
                             <div class="carousel-indicators">
                                 {% for m in r.media %}
+                                    {# each indicator jumps to a specific slide by index (loop.index0 = 0-based) #}
+                                    {# the first one is marked 'active' so it's highlighted on page load #}
                                     <button type="button"
                                             data-bs-target="#carousel-{{ r.id }}"
                                             data-bs-slide-to="{{ loop.index0 }}"
@@ -66,15 +50,20 @@
                             </div>
                         {% endif %}
 
+                        {# ---- the actual slides (images or videos) ---- #}
+                        {# black background so portrait photos have nice letterbox padding #}
                         <div class="carousel-inner rounded border" style="background-color: #000;">
                             {% for m in r.media %}
+                                {# 'active' class marks the slide that's shown first #}
                                 <div class="carousel-item {{ 'active' if loop.first else '' }}">
                                     {% if m.media_type == 'image' %}
+                                        {# object-fit: contain = show the whole image, don't crop #}
                                         <img src="{{ url_for('static', filename='uploads/' + m.filename) }}"
                                              class="d-block w-100"
                                              style="height: 400px; object-fit: contain;"
                                              alt="{{ m.original_name }}">
                                     {% else %}
+                                        {# same styling, but for video — controls attribute adds play/pause UI #}
                                         <video src="{{ url_for('static', filename='uploads/' + m.filename) }}"
                                                controls
                                                class="d-block w-100"
@@ -84,7 +73,8 @@
                             {% endfor %}
                         </div>
 
-                        {# previous / next arrows only appear when there's more than one media item #}
+                        {# ---- left/right arrow buttons ---- #}
+                        {# also hidden if there's only one attachment (no slides to go between) #}
                         {% if r.media | length > 1 %}
                             <button class="carousel-control-prev" type="button"
                                     data-bs-target="#carousel-{{ r.id }}" data-bs-slide="prev">

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -21,9 +21,14 @@
     <ul class="list-group">
         {% for r in recent_reports %}
             <li class="list-group-item">
-                <span class="badge me-2" style="background-color: {{ r.category.marker_color }};">{{ r.category.name }}</span>
-                {{ r.suburb.name }}, {{ r.suburb.state.code }}
-                <span class="text-muted">— {{ r.created_at.strftime('%d %b %Y, %H:%M') }}</span>
+                <div class="d-flex justify-content-between align-items-start">
+                    <div>
+                        <span class="badge me-2" style="background-color: {{ r.category.marker_color }};">{{ r.category.name }}</span>
+                        {{ r.suburb.name }}, {{ r.suburb.state.code }}
+                        <span class="text-muted">— {{ r.created_at.strftime('%d %b %Y, %H:%M') }}</span>
+                    </div>
+                    <a href="{{ url_for('edit_report_page', report_id=r.id) }}" class="btn btn-sm btn-outline-secondary">Edit</a>
+                </div>
                 {% if r.description %}<div class="mt-1">{{ r.description }}</div>{% endif %}
 
                 {# ---------- image/video carousel for this report ---------- #}

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -1,6 +1,35 @@
 {% extends "base.html" %}
 
 {% block content %}
+<style>
+    /* make the carousel arrows very obvious — solid dark circles, scale up on hover */
+    .carousel-control-prev,
+    .carousel-control-next {
+        width: 60px;
+        opacity: 1;
+    }
+    .carousel-control-prev-icon,
+    .carousel-control-next-icon {
+        background-color: rgba(0, 0, 0, 0.6);
+        border-radius: 50%;
+        width: 44px;
+        height: 44px;
+        background-size: 60%;
+        background-position: center;
+        transition: transform 0.15s ease, background-color 0.15s ease;
+    }
+    .carousel-control-prev:hover .carousel-control-prev-icon,
+    .carousel-control-next:hover .carousel-control-next-icon {
+        background-color: rgba(0, 0, 0, 0.9);
+        transform: scale(1.2);
+    }
+    /* indicator dots stay visible on any background */
+    .carousel-indicators [data-bs-target] {
+        background-color: rgba(255, 255, 255, 0.9);
+        border: 1px solid rgba(0, 0, 0, 0.4);
+    }
+</style>
+
 <h1>My Profile</h1>
 
 <div class="card mb-4">
@@ -23,22 +52,51 @@
                 {% if r.description %}<div class="mt-1">{{ r.description }}</div>{% endif %}
 
                 {% if r.media %}
-                    <div class="row g-2 mt-2">
-                        {% for m in r.media %}
-                            <div class="col-12 col-md-6">
-                                {% if m.media_type == 'image' %}
-                                    <img src="{{ url_for('static', filename='uploads/' + m.filename) }}"
-                                         class="rounded border"
-                                         style="width: 100%; height: 350px; object-fit: cover;"
-                                         alt="{{ m.original_name }}">
-                                {% else %}
-                                    <video src="{{ url_for('static', filename='uploads/' + m.filename) }}"
-                                           controls
-                                           class="rounded border"
-                                           style="width: 100%; height: 350px; object-fit: cover;"></video>
-                                {% endif %}
+                    <div id="carousel-{{ r.id }}" class="carousel slide mt-2" data-bs-ride="false">
+                        {# dots at the top showing which slide you're on, 1 per media item #}
+                        {% if r.media | length > 1 %}
+                            <div class="carousel-indicators">
+                                {% for m in r.media %}
+                                    <button type="button"
+                                            data-bs-target="#carousel-{{ r.id }}"
+                                            data-bs-slide-to="{{ loop.index0 }}"
+                                            class="{{ 'active' if loop.first else '' }}"
+                                            aria-label="Slide {{ loop.index }}"></button>
+                                {% endfor %}
                             </div>
-                        {% endfor %}
+                        {% endif %}
+
+                        <div class="carousel-inner rounded border" style="background-color: #000;">
+                            {% for m in r.media %}
+                                <div class="carousel-item {{ 'active' if loop.first else '' }}">
+                                    {% if m.media_type == 'image' %}
+                                        <img src="{{ url_for('static', filename='uploads/' + m.filename) }}"
+                                             class="d-block w-100"
+                                             style="height: 400px; object-fit: contain;"
+                                             alt="{{ m.original_name }}">
+                                    {% else %}
+                                        <video src="{{ url_for('static', filename='uploads/' + m.filename) }}"
+                                               controls
+                                               class="d-block w-100"
+                                               style="height: 400px; object-fit: contain; background: #000;"></video>
+                                    {% endif %}
+                                </div>
+                            {% endfor %}
+                        </div>
+
+                        {# previous / next arrows only appear when there's more than one media item #}
+                        {% if r.media | length > 1 %}
+                            <button class="carousel-control-prev" type="button"
+                                    data-bs-target="#carousel-{{ r.id }}" data-bs-slide="prev">
+                                <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+                                <span class="visually-hidden">Previous</span>
+                            </button>
+                            <button class="carousel-control-next" type="button"
+                                    data-bs-target="#carousel-{{ r.id }}" data-bs-slide="next">
+                                <span class="carousel-control-next-icon" aria-hidden="true"></span>
+                                <span class="visually-hidden">Next</span>
+                            </button>
+                        {% endif %}
                     </div>
                 {% endif %}
             </li>

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -21,6 +21,26 @@
                 {{ r.suburb.name }}, {{ r.suburb.state.code }}
                 <span class="text-muted">— {{ r.created_at.strftime('%d %b %Y, %H:%M') }}</span>
                 {% if r.description %}<div class="mt-1">{{ r.description }}</div>{% endif %}
+
+                {% if r.media %}
+                    <div class="row g-2 mt-2">
+                        {% for m in r.media %}
+                            <div class="col-12 col-md-6">
+                                {% if m.media_type == 'image' %}
+                                    <img src="{{ url_for('static', filename='uploads/' + m.filename) }}"
+                                         class="rounded border"
+                                         style="width: 100%; height: 350px; object-fit: cover;"
+                                         alt="{{ m.original_name }}">
+                                {% else %}
+                                    <video src="{{ url_for('static', filename='uploads/' + m.filename) }}"
+                                           controls
+                                           class="rounded border"
+                                           style="width: 100%; height: 350px; object-fit: cover;"></video>
+                                {% endif %}
+                            </div>
+                        {% endfor %}
+                    </div>
+                {% endif %}
             </li>
         {% endfor %}
     </ul>

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -1,0 +1,30 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1>My Profile</h1>
+
+<div class="card mb-4">
+    <div class="card-body">
+        <h5 class="card-title">{{ current_user.username }}</h5>
+        <p class="card-text mb-1"><strong>Email:</strong> {{ current_user.email }}</p>
+        <p class="card-text mb-1"><strong>Trust score:</strong> {{ current_user.trust_score }}</p>
+        <p class="card-text mb-0"><strong>Reports submitted:</strong> {{ current_user.reports | length }}</p>
+    </div>
+</div>
+
+<h3>Recent Reports</h3>
+{% if recent_reports %}
+    <ul class="list-group">
+        {% for r in recent_reports %}
+            <li class="list-group-item">
+                <span class="badge me-2" style="background-color: {{ r.category.marker_color }};">{{ r.category.name }}</span>
+                {{ r.suburb.name }}, {{ r.suburb.state.code }}
+                <span class="text-muted">— {{ r.created_at.strftime('%d %b %Y, %H:%M') }}</span>
+                {% if r.description %}<div class="mt-1">{{ r.description }}</div>{% endif %}
+            </li>
+        {% endfor %}
+    </ul>
+{% else %}
+    <p class="text-muted">You haven't submitted any reports yet.</p>
+{% endif %}
+{% endblock %}

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -5,14 +5,17 @@
 {% endblock %}
 
 {% block content %}
-<h1>My Profile</h1>
+<h1>{{ "My Profile" if is_own_profile else user.username + "'s Profile" }}</h1>
 
 <div class="card mb-4">
     <div class="card-body">
-        <h5 class="card-title">{{ current_user.username }}</h5>
-        <p class="card-text mb-1"><strong>Email:</strong> {{ current_user.email }}</p>
-        <p class="card-text mb-1"><strong>Trust score:</strong> {{ current_user.trust_score }}</p>
-        <p class="card-text mb-0"><strong>Reports submitted:</strong> {{ current_user.reports | length }}</p>
+        <h5 class="card-title">{{ user.username }}</h5>
+        {# email is private — only shown on your own profile #}
+        {% if is_own_profile %}
+            <p class="card-text mb-1"><strong>Email:</strong> {{ user.email }}</p>
+        {% endif %}
+        <p class="card-text mb-1"><strong>Trust score:</strong> {{ user.trust_score }}</p>
+        <p class="card-text mb-0"><strong>Reports submitted:</strong> {{ user.reports | length }}</p>
     </div>
 </div>
 
@@ -27,7 +30,10 @@
                         {{ r.suburb.name }}, {{ r.suburb.state.code }}
                         <span class="text-muted">— {{ r.created_at.strftime('%d %b %Y, %H:%M') }}</span>
                     </div>
-                    <a href="{{ url_for('edit_report_page', report_id=r.id) }}" class="btn btn-sm btn-outline-secondary">Edit</a>
+                    {# Edit button only shown on your own profile — can't edit others' posts #}
+                    {% if is_own_profile %}
+                        <a href="{{ url_for('edit_report_page', report_id=r.id) }}" class="btn btn-sm btn-outline-secondary">Edit</a>
+                    {% endif %}
                 </div>
                 {% if r.description %}<div class="mt-1">{{ r.description }}</div>{% endif %}
 
@@ -98,6 +104,6 @@
         {% endfor %}
     </ul>
 {% else %}
-    <p class="text-muted">You haven't submitted any reports yet.</p>
+    <p class="text-muted">{{ "You haven't submitted any reports yet." if is_own_profile else user.username + " hasn't submitted any reports yet." }}</p>
 {% endif %}
 {% endblock %}

--- a/app/templates/report_edit.html
+++ b/app/templates/report_edit.html
@@ -1,12 +1,16 @@
 {% extends "base.html" %}
 
+{% block styles %}
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/report_edit.css') }}">
+{% endblock %}
+
 {% block content %}
 <h1>Edit Report</h1>
 <p class="text-muted">Update the details of your report.</p>
 
 <div class="card">
     <div class="card-body">
-        <form method="POST">
+        <form method="POST" enctype="multipart/form-data">
             <div class="mb-3">
                 <label class="form-label">State <span class="text-danger">*</span></label>
                 <select id="state_id" class="form-select" required>
@@ -56,13 +60,45 @@
                 <textarea id="description" name="description" class="form-control" rows="3">{{ report.description or '' }}</textarea>
             </div>
 
-            {# media editing is out of scope for this PR — attachments stay as they were #}
+            {# ---------- existing attachments: click the X to mark for deletion on save ---------- #}
             {% if report.media %}
-                <p class="text-muted small mb-3">
-                    This report has {{ report.media | length }} attachment{{ '' if report.media|length == 1 else 's' }}.
-                    Attachments can't be edited yet — they'll stay as they are.
-                </p>
+                <div class="mb-3">
+                    <label class="form-label">Current attachments</label>
+                    <div class="row g-2">
+                        {% for m in report.media %}
+                            {# wrapper gets hidden when the user clicks its X — the checkbox inside stays in the form and submits the delete id #}
+                            <div class="col-6 col-md-4 attachment-thumb">
+                                <div class="border rounded p-2 position-relative">
+                                    {% if m.media_type == 'image' %}
+                                        <img src="{{ url_for('static', filename='uploads/' + m.filename) }}"
+                                             class="d-block w-100"
+                                             style="height: 140px; object-fit: cover;"
+                                             alt="{{ m.original_name }}">
+                                    {% else %}
+                                        <video src="{{ url_for('static', filename='uploads/' + m.filename) }}"
+                                               class="d-block w-100"
+                                               style="height: 140px; object-fit: cover;"
+                                               muted></video>
+                                    {% endif %}
+
+                                    {# X button: JS ticks the hidden checkbox and hides this whole thumbnail #}
+                                    <button type="button" class="remove-btn" aria-label="Remove attachment">×</button>
+
+                                    {# hidden — checked by the X button's click handler, submits with the form #}
+                                    <input type="checkbox" name="delete_media_ids" value="{{ m.id }}">
+                                </div>
+                            </div>
+                        {% endfor %}
+                    </div>
+                </div>
             {% endif %}
+
+            {# ---------- add new attachments ---------- #}
+            <div class="mb-3">
+                <label class="form-label">Add Image/Video <span class="text-muted">(optional, max 5 total)</span></label>
+                <input id="media" name="media" type="file" class="form-control"
+                       accept="image/*,video/*" multiple>
+            </div>
 
             <button type="submit" class="btn btn-primary">Save Changes</button>
             <a href="{{ url_for('profile_page') }}" class="btn btn-outline-secondary">Cancel</a>
@@ -85,6 +121,16 @@
             opt.textContent = sub.name;
             suburbSelect.appendChild(opt);
         }
+    });
+
+    // clicking the X on a current attachment: tick its hidden checkbox and hide the thumbnail
+    // the checkbox stays in the form so the server still receives the delete id on submit
+    document.querySelectorAll('.attachment-thumb .remove-btn').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const thumb = btn.closest('.attachment-thumb');
+            thumb.querySelector('input[type="checkbox"]').checked = true;
+            thumb.style.display = 'none';
+        });
     });
 </script>
 {% endblock %}

--- a/app/templates/report_edit.html
+++ b/app/templates/report_edit.html
@@ -1,0 +1,90 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1>Edit Report</h1>
+<p class="text-muted">Update the details of your report.</p>
+
+<div class="card">
+    <div class="card-body">
+        <form method="POST">
+            <div class="mb-3">
+                <label class="form-label">State <span class="text-danger">*</span></label>
+                <select id="state_id" class="form-select" required>
+                    <option value="" disabled>Select a state...</option>
+                    {% for state in states %}
+                        {# pre-select the state that contains the report's current suburb #}
+                        <option value="{{ state.id }}" {{ 'selected' if state.id == report.suburb.state_id else '' }}>
+                            {{ state.name }}
+                        </option>
+                    {% endfor %}
+                </select>
+            </div>
+
+            <div class="mb-3">
+                <label class="form-label">Suburb <span class="text-danger">*</span></label>
+                <select id="suburb_id" name="suburb_id" class="form-select" required>
+                    {# pre-populate with the suburbs from the report's current state so the dropdown isn't empty on load #}
+                    {% for sub in report.suburb.state.suburbs %}
+                        <option value="{{ sub.id }}" {{ 'selected' if sub.id == report.suburb_id else '' }}>
+                            {{ sub.name }}
+                        </option>
+                    {% endfor %}
+                </select>
+            </div>
+
+            <div class="mb-3">
+                <label class="form-label">Specific Address <span class="text-muted">(optional)</span></label>
+                <input id="address" name="address" type="text" class="form-control" maxlength="200"
+                       value="{{ report.address or '' }}"
+                       placeholder="e.g. corner of Hay St and William St">
+            </div>
+
+            <div class="mb-3">
+                <label class="form-label">Category <span class="text-danger">*</span></label>
+                <select id="category_id" name="category_id" class="form-select" required>
+                    {% for cat in categories %}
+                        <option value="{{ cat.id }}" style="color: {{ cat.marker_color }};"
+                                {{ 'selected' if cat.id == report.category_id else '' }}>
+                            {{ cat.name }}
+                        </option>
+                    {% endfor %}
+                </select>
+            </div>
+
+            <div class="mb-3">
+                <label class="form-label">Description <span class="text-muted">(optional)</span></label>
+                <textarea id="description" name="description" class="form-control" rows="3">{{ report.description or '' }}</textarea>
+            </div>
+
+            {# media editing is out of scope for this PR — attachments stay as they were #}
+            {% if report.media %}
+                <p class="text-muted small mb-3">
+                    This report has {{ report.media | length }} attachment{{ '' if report.media|length == 1 else 's' }}.
+                    Attachments can't be edited yet — they'll stay as they are.
+                </p>
+            {% endif %}
+
+            <button type="submit" class="btn btn-primary">Save Changes</button>
+            <a href="{{ url_for('profile_page') }}" class="btn btn-outline-secondary">Cancel</a>
+        </form>
+    </div>
+</div>
+
+<script>
+    // cascade: when user changes state, swap the suburb dropdown contents to match
+    const SUBURBS_BY_STATE = {{ suburbs_by_state | tojson }};
+    const stateSelect = document.getElementById('state_id');
+    const suburbSelect = document.getElementById('suburb_id');
+
+    stateSelect.addEventListener('change', () => {
+        const suburbs = SUBURBS_BY_STATE[stateSelect.value] || [];
+        suburbSelect.innerHTML = '';
+        for (const sub of suburbs) {
+            const opt = document.createElement('option');
+            opt.value = sub.id;
+            opt.textContent = sub.name;
+            suburbSelect.appendChild(opt);
+        }
+    });
+</script>
+{% endblock %}

--- a/app/templates/search.html
+++ b/app/templates/search.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1>Search Users</h1>
+
+<form method="get" action="{{ url_for('search_users_page') }}" class="mb-4">
+    <div class="input-group">
+        <input type="text" name="q" class="form-control"
+               placeholder="Search by username..."
+               value="{{ q or '' }}" autofocus>
+        <button type="submit" class="btn btn-primary">Search</button>
+    </div>
+</form>
+
+{% if q %}
+    <h5 class="text-muted">Results for "{{ q }}"</h5>
+    {% if users %}
+        <ul class="list-group">
+            {% for u in users %}
+                <li class="list-group-item d-flex justify-content-between align-items-center">
+                    <span>
+                        <strong>{{ u.username }}</strong>
+                        <span class="text-muted ms-2">— {{ u.reports | length }} reports</span>
+                    </span>
+                    <a href="{{ url_for('user_profile_page', username=u.username) }}" class="btn btn-sm btn-outline-primary">View Profile</a>
+                </li>
+            {% endfor %}
+        </ul>
+    {% else %}
+        <p class="text-muted">No users match "{{ q }}".</p>
+    {% endif %}
+{% endif %}
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ flask
 flask-sqlalchemy
 flask-login
 flask-wtf
+email-validator


### PR DESCRIPTION
## Summary
Implements Issue #7 — user profile + search. Logged-in users can view their own profile, edit their reports (including adding/removing attachments), view other users' profiles (read-only), and search for users by username from the navbar.

## Changes
- **`/profile`** — your own profile: username, email, trust score, recent reports with a Bootstrap carousel for attached images/videos.
- **`/reports/<id>/edit`** — edit your own reports. Text fields + add new attachments + click the X on existing thumbnails to remove them. Only the author can edit (403 otherwise).
- **`/users/<username>`** — view another user's profile. Same layout as `/profile` but with email + Edit buttons hidden.
- **`/search?q=…`** — search users by username substring, case-insensitive.
- **Navbar** — added a search box and made the username a link to own profile.
- **Seed data** — alice, bob, charlie (password `Test@1234`) with one sample report each so search has something to return.
- **CSS cleanup** — page-specific styles moved into `static/css/profile.css` and `static/css/report_edit.css`; loaded via new `{% block styles %}` slot in `base.html`.

## How to test
1. `rm app.db && python run.py`
2. Log in as yourself, visit `/profile` (Edit buttons visible).
3. Edit a report — tick X on a thumbnail to remove it, add a new image, save.
4. Type `ali` in the navbar search → view alice's profile → confirm no Edit button.

## Not in this PR (follow-ups)
- IDOR hardening (switching `/reports/<int:id>` to UUID-based URLs)
- Searching reports by text
- Edit own email/password from profile
- - 
## ⚠️ Seeded test users

For search demo purposes, these 3 users are auto-seeded in the DB on app startup:

| Username | Email            | Password    |
|----------|------------------|-------------|
| alice    | alice@test.com   | Test@1234   |
| bob      | bob@test.com     | Test@1234   |
| charlie  | charlie@test.com | Test@1234   |

Each comes with one sample report:
- **alice** → Sydney, Weather
- **bob** → Melbourne, Traffic
- **charlie** → Perth, Hazards

The seed is **idempotent** (skips any that already exist), so it won't overwrite anything.

**TODO for a future PR**: remove these before final submission, OR gate them behind a `FLASK_ENV=development` check so they don't appear in production.

Seed logic lives in `app/__init__.py` → `DEFAULT_TEST_USERS`, `DEFAULT_TEST_REPORTS`, `seed_test_users_and_reports()`.

Closes #7
