### PR TITLE
W3C validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,10 @@ instance/
 app/static/uploads/*
 !app/static/uploads/.gitkeep
 
+# local W3C validation helper + rendered output (dev-only)
+_w3c_check.py
+_w3c_rendered/
+
 # Scrapy stuff:
 .scrapy
 

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -93,7 +93,7 @@
             Menu
         </button>
 
-        <div class="offcanvas offcanvas-start text-bg-dark d-md-none" tabindex="-1" id="mobileSidebar" aria-labelledby="mobileSidebarLabel">
+        <div class="offcanvas offcanvas-start text-bg-dark d-md-none" tabindex="-1" id="mobileSidebar" aria-labelledby="mobileSidebarLabel" role="dialog">
             <div class="offcanvas-header border-bottom border-secondary">
                 <h5 class="offcanvas-title" id="mobileSidebarLabel">Navigation</h5>
                 <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" aria-label="Close"></button>
@@ -264,7 +264,7 @@
                Auth-only: guests get a stub alert instead. #}
             <aside id="user-search-panel" class="user-search-panel" aria-hidden="true">
                 <div class="user-search-header">
-                    <h3 class="user-search-title">Search Users</h3>
+                    <h2 class="user-search-title">Search Users</h2>
                     <button type="button" class="user-search-close" aria-label="Close search">×</button>
                 </div>
                 <div class="user-search-input-wrap">

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -57,6 +57,10 @@
             </a>
 
             <div class="app-navbar-right">
+                {# Hamburger only renders when the mobile sidebar is also rendered
+                   (i.e. when show_app is true) — otherwise aria-controls would
+                   reference an element that doesn't exist on the page. #}
+                {% if show_app %}
                 <button class="btn btn-link d-md-none app-navbar-menu-btn" type="button" data-bs-toggle="offcanvas" data-bs-target="#mobileSidebar" aria-controls="mobileSidebar" aria-label="Open navigation menu">
                     <svg class="app-hamburger-icon" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                         <line x1="3" y1="6" x2="21" y2="6"></line>
@@ -64,6 +68,7 @@
                         <line x1="3" y1="18" x2="21" y2="18"></line>
                     </svg>
                 </button>
+                {% endif %}
                 {% if current_user.is_authenticated %}
                     <a href="{{ url_for('main.messages_page') }}"
                        class="app-navbar-message"
@@ -82,9 +87,9 @@
                                      alt="Your profile picture"
                                      class="app-navbar-profile-image">
                             {% else %}
-                                <div class="app-navbar-profile-initials">
+                                <span class="app-navbar-profile-initials">
                                     {{ current_user.username[0].upper() }}
-                                </div>
+                                </span>
                             {% endif %}
                             <span class="app-navbar-profile-chevron" aria-hidden="true">▾</span>
                         </button>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -535,6 +535,7 @@
                 <div class="home-demo-base"></div>
             </div>
         </div>
+    </div>
 </section>
 
 {% endblock %}

--- a/app/templates/map.html
+++ b/app/templates/map.html
@@ -110,7 +110,7 @@
 	</section>
 
 	<div class="map-wrapper">
-		<div id="map" aria-label="Interactive Australia map"></div>
+		<div id="map" role="region" aria-label="Interactive Australia map"></div>
 		<div class="zoom-controls">
 			<button type="button" onclick="zoom(true)">+</button>
 			<button type="button" onclick="zoom(false)">-</button>

--- a/app/templates/messages.html
+++ b/app/templates/messages.html
@@ -40,21 +40,21 @@
         </header>
 
         <div class="messages-tabs" role="tablist">
-            <button type="button" class="messages-tab is-active" data-tab="chats" role="tab" aria-selected="true">
+            <button type="button" class="messages-tab is-active" data-tab="chats" id="chats-tab" role="tab" aria-selected="true" aria-controls="chats-panel">
                 Chats <span class="messages-tab-count" id="chats-count">0</span>
             </button>
-            <button type="button" class="messages-tab" data-tab="requests" role="tab" aria-selected="false">
+            <button type="button" class="messages-tab" data-tab="requests" id="requests-tab" role="tab" aria-selected="false" aria-controls="requests-panel">
                 Requests <span class="messages-tab-count messages-tab-count-warn" id="requests-count">0</span>
             </button>
         </div>
 
         {# tab panes — only one visible at a time #}
-        <div class="messages-list-wrap" data-pane="chats">
+        <div class="messages-list-wrap" data-pane="chats" id="chats-panel" role="tabpanel" aria-labelledby="chats-tab">
             <ul class="messages-list" id="chats-list"></ul>
             <p class="messages-empty" id="chats-empty" hidden>No chats yet — start one from someone's profile.</p>
         </div>
 
-        <div class="messages-list-wrap" data-pane="requests" hidden>
+        <div class="messages-list-wrap" data-pane="requests" id="requests-panel" role="tabpanel" aria-labelledby="requests-tab" hidden>
             <ul class="messages-list" id="requests-list"></ul>
             <p class="messages-empty" id="requests-empty" hidden>No message requests.</p>
         </div>
@@ -113,10 +113,11 @@
 
             <form class="messages-composer" id="thread-composer" enctype="multipart/form-data" autocomplete="off">
                 {# attach button — paperclip icon triggers the hidden file input #}
-                <label for="thread-media" class="messages-composer-attach" title="Attach images / videos" aria-label="Attach images / videos">
+                <label for="thread-media" class="messages-composer-attach" title="Attach images / videos">
                     <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                         <path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"/>
                     </svg>
+                    <span class="visually-hidden">Attach images or videos</span>
                 </label>
                 <input id="thread-media" type="file" class="visually-hidden-input"
                        accept="image/*,video/*" multiple>
@@ -143,11 +144,11 @@
 {# Blocked-users list modal — opened by the small icon next to "Messages" in
    the sidebar header. Shows everyone the current user has blocked + a quick
    Unblock button next to each entry. Empty state shown when nobody's blocked. #}
-<div class="modal fade" id="blocked-list-modal" tabindex="-1" aria-labelledby="blocked-list-title" aria-hidden="true">
+<div class="modal fade" id="blocked-list-modal" tabindex="-1" aria-labelledby="blocked-list-title" aria-hidden="true" role="dialog">
     <div class="modal-dialog modal-dialog-centered">
         <div class="modal-content delete-modal-content">
             <div class="modal-header">
-                <h5 class="modal-title" id="blocked-list-title">Blocked users</h5>
+                <h2 class="modal-title" id="blocked-list-title">Blocked users</h2>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <div class="modal-body">
@@ -165,11 +166,11 @@
    button based on the current block state when it's opened. Same Bootstrap
    pattern as the delete-report and unfollow modals so the design language is
    consistent across the app. #}
-<div class="modal fade" id="block-confirm-modal" tabindex="-1" aria-labelledby="block-confirm-title" aria-hidden="true">
+<div class="modal fade" id="block-confirm-modal" tabindex="-1" aria-labelledby="block-confirm-title" aria-hidden="true" role="dialog">
     <div class="modal-dialog modal-dialog-centered">
         <div class="modal-content delete-modal-content">
             <div class="modal-header">
-                <h5 class="modal-title" id="block-confirm-title">Block this user?</h5>
+                <h2 class="modal-title" id="block-confirm-title">Block this user?</h2>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <div class="modal-body" id="block-confirm-body">

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -173,7 +173,7 @@
                     <div class="profile-post-header">
                         <span class="profile-post-icon" aria-hidden="true">{{ CATEGORY_EMOJI.get(r.category.name, '📝') }}</span>
                         <div class="profile-post-titles">
-                            <h3 class="profile-post-title">{{ r.category.name }} in {{ r.city.name }}</h3>
+                            <h2 class="profile-post-title">{{ r.category.name }} in {{ r.city.name }}</h2>
                             <div class="profile-post-sub">
                                 <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                                     <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"/>
@@ -463,11 +463,11 @@
    delete modals. Only rendered on someone else's profile when the viewer is
    logged in (the only case where the Follow button exists). #}
 {% if not is_own_profile and current_user.is_authenticated %}
-<div class="modal fade" id="unfollow-modal" tabindex="-1" aria-labelledby="unfollow-modal-label" aria-hidden="true">
+<div class="modal fade" id="unfollow-modal" tabindex="-1" aria-labelledby="unfollow-modal-label" aria-hidden="true" role="dialog">
     <div class="modal-dialog modal-dialog-centered">
         <div class="modal-content delete-modal-content">
             <div class="modal-header">
-                <h5 class="modal-title" id="unfollow-modal-label">Unfollow {{ user.username }}?</h5>
+                <h4 class="modal-title" id="unfollow-modal-label">Unfollow {{ user.username }}?</h4>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <div class="modal-body">

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -194,7 +194,7 @@
                             <div class="own-report-actions">
                                 <a href="{{ url_for('reports.view_report', token=r.id|report_token) }}" class="own-report-tag">Your report</a>
                                 <a href="{{ url_for('reports.edit_report_page', report_id=r.id) }}" class="listing-item-edit">
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-with="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                                         <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/>
                                         <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/>
                                     </svg>

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -467,7 +467,7 @@
     <div class="modal-dialog modal-dialog-centered">
         <div class="modal-content delete-modal-content">
             <div class="modal-header">
-                <h4 class="modal-title" id="unfollow-modal-label">Unfollow {{ user.username }}?</h4>
+                <h3 class="modal-title" id="unfollow-modal-label">Unfollow {{ user.username }}?</h3>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <div class="modal-body">

--- a/app/templates/profile_edit.html
+++ b/app/templates/profile_edit.html
@@ -134,13 +134,13 @@
                 <div class="settings-avatar-previews avatar-modal-previews">
                     <figure class="settings-avatar-figure">
                         <div class="settings-avatar-preview" id="modal-preview-circle">
-                            <img id="modal-preview-circle-img" alt="New avatar preview (round)">
+                            <img id="modal-preview-circle-img" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAIBRAA7" alt="New avatar preview (round)">
                         </div>
                         <figcaption>Chat &amp; comments</figcaption>
                     </figure>
                     <figure class="settings-avatar-figure">
                         <div class="settings-avatar-preview-square" id="modal-preview-square">
-                            <img id="modal-preview-square-img" alt="New avatar preview (profile hero)">
+                            <img id="modal-preview-square-img" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAIBRAA7" alt="New avatar preview (profile hero)">
                         </div>
                         <figcaption>Profile page</figcaption>
                     </figure>

--- a/app/templates/reports.html
+++ b/app/templates/reports.html
@@ -39,6 +39,7 @@
             <div class="mb-3">
                 <label class="form-label">Category <span class="text-danger">*</span></label>
                 <select id="category_id" class="form-select" required>
+                    <option value="" disabled selected>Pick a category</option>
                     {% for cat in categories %}
                         <option value="{{ cat.id }}" style="color: {{ cat.marker_color }}">
                             {{ cat.name }}


### PR DESCRIPTION
## What lands

- **30+ W3C HTML validation errors fixed** across the site. Most were
  pre-existing; the remaining handful were introduced by the merged
  PR #94 UI overhaul and fixed here.
- Original accessibility tweaks:
  - `role="dialog"` on the mobile sidebar offcanvas
  - heading hierarchy adjustments (h3 → h2 where appropriate)
  - 28 misc errors across base.html, map.html, messages.html,
    profile.html, reports.html
- Post-merge fixes for errors PR #94 introduced:
  - `index.html` — close unbalanced `<div>` in `home-hero-grid`
  - `base.html` — profile-dropdown `<div>` → `<span>` (W3C forbids
    `<div>` inside `<button>`); CSS uses `display:flex` so layout
    is unchanged
  - `base.html` — hamburger button now conditionally renders via
    `{% if show_app %}` so `aria-controls` doesn't reference a
    non-existent `#mobileSidebar` on login / signup / intro pages
  - `profile.html` — `stroke-with="2"` → `stroke-width="2"` on 3
    edit-icon SVGs (now render at the intended 2px stroke)
  - `profile_edit.html` — transparent 1×1 GIF placeholder `src` on
    the modal preview imgs (JS overwrites src when user picks a file)

## Test plan

- [ ] `pytest tests/unit/` — expect 18 passed
- [ ] `py _w3c_check.py` (renders every page via Flask test client,
      runs html5validator) — expect **0 errors**, ~53 info-level
      warnings (non-blocking "lacks heading" advisory hints on the
      home-page demo carousel cards)
- [ ] App boots normally with `flask run`
- [ ] Visually check intro / map / listing / profile / favourites —
      no regressions vs main
- [ ] Login / signup / intro pages no longer render an orphan
      hamburger button
